### PR TITLE
Delete com.palantir.less.lessBuilder.launch

### DIFF
--- a/magic-app/.externalToolBuilders/com.palantir.less.lessBuilder.launch
+++ b/magic-app/.externalToolBuilders/com.palantir.less.lessBuilder.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_DISABLED_BUILDER" value="com.palantir.less.lessBuilder"/>
-<mapAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS"/>
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-</launchConfiguration>


### PR DESCRIPTION
Probably not needed anymore. I actually don't know anything about AntBuilder so maybe we just need to change `value=com.palantir.less.lessBuilder` and the file name
