### PR TITLE
Brian/fix 6player bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .checkstyle
 
+.idea/
 .gradle/
 .settings/
 node_modules/
@@ -10,3 +11,4 @@ log/
 /data/
 
 magic-distribution/src/dev/data
+magic-server/out

--- a/magic-server/src/main/java/magic/data/Pairing.java
+++ b/magic-server/src/main/java/magic/data/Pairing.java
@@ -13,7 +13,7 @@ public class Pairing implements Comparable<Pairing> {
     public Pairing(@JsonProperty("player1") Player player1,
                    @JsonProperty("player2") Player player2,
                    @JsonProperty("totalPoints") int totalPoints) {
-        this.totalPoints = Preconditions.checkNotNull(totalPoints);
+        this.totalPoints = totalPoints;
         Preconditions.checkNotNull(player1, "Player 1 cannot be null!");
         Preconditions.checkNotNull(player2, "Player 2 cannot be null!");
         if (player1.getId() < player2.getId()) {

--- a/magic-server/src/main/java/magic/tournament/AbstractTournament.java
+++ b/magic-server/src/main/java/magic/tournament/AbstractTournament.java
@@ -13,7 +13,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -135,9 +134,6 @@ public abstract class AbstractTournament implements Tournament {
     }
 
     /**
-     *
-     * @param roundRequested
-     * @param thisRoundResults
      * @return - the next round (without results) or null if the tournament is complete
      */
     @Override
@@ -157,7 +153,7 @@ public abstract class AbstractTournament implements Tournament {
             Round expectedRound = this.data.getRounds().pollLast();
             NavigableSet<Match> correctedInput = Sets.newTreeSet();
             Map<Pairing, Match> matchesReceived =
-                    thisRoundResults.stream().collect(Collectors.toMap(m -> m.getPairing(), Function.identity()));
+                    thisRoundResults.stream().collect(Collectors.toMap(Match::getPairing, Function.identity()));
             for (Match m : expectedRound.getMatches()) {
                 Pairing p = m.getPairing();
                 if (!matchesReceived.containsKey(p)) {

--- a/magic-server/src/main/java/magic/tournament/TieBreakers.java
+++ b/magic-server/src/main/java/magic/tournament/TieBreakers.java
@@ -82,14 +82,14 @@ public class TieBreakers implements Comparable<TieBreakers> {
 
     public static Map<Player, Integer> calculatePointsPerPlayer(Collection<Round> results) {
         Map<Player, Integer> pointsPerPlayer = Maps.newHashMap();
-        results.stream().filter(r -> r.isComplete()).forEach(r -> {
+        results.stream().filter(Round::isComplete).forEach(r ->
             r.getMatches().forEach(m -> {
                 Player player1 = m.getPairing().getPlayer1();
                 Player player2 = m.getPairing().getPlayer2();
                 pointsPerPlayer.merge(player1, m.getPointsForPlayer(player1), Integer::sum);
                 pointsPerPlayer.merge(player2, m.getPointsForPlayer(player2), Integer::sum);
-            });
-        });
+            })
+        );
         return pointsPerPlayer;
     }
 
@@ -97,11 +97,6 @@ public class TieBreakers implements Comparable<TieBreakers> {
      * Creates a value that is intended to be compared against similarly generated values to ensure
      * that each player is paired against a (pseudo)random but deterministic opponent in each round.
      * Each input is a parameter for which the output should be unique.
-     *
-     * @param tournamentId
-     * @param playerId
-     * @param round
-     * @return
      */
     public static String generateRandomTieBreaker(String tournamentId, long playerID, Integer round) {
     	if (playerID == Player.BYE.getId()) {

--- a/magic-server/src/main/java/magic/tournament/TournamentManager.java
+++ b/magic-server/src/main/java/magic/tournament/TournamentManager.java
@@ -71,14 +71,14 @@ public final class TournamentManager {
     }
 
     private TournamentInput registerPlayers(TournamentInput input) {
-        List<String> playersToRegister = input.getPlayers().stream().filter(p -> p.getId() <= 0).map(p -> p.getName())
+        List<String> playersToRegister = input.getPlayers().stream().filter(p -> p.getId() <= 0).map(Player::getName)
                 .collect(Collectors.toList());
         try {
             Map<String, Player> newPlayers = this.db.registerPlayers(playersToRegister);
             Set<Player> seen = Sets.newHashSet();
             Set<Player> players = this.db.getPlayers();
             List<Player> withIds = Lists.newArrayList();
-            input.getPlayers().stream().forEach(p -> {
+            input.getPlayers().forEach(p -> {
                 if (p.getId() > 0) {
                 	if (!players.contains(p)) {
                 		throw new IllegalArgumentException("Player " + p.getName() + " is not in the database!");

--- a/magic-server/src/main/java/magic/tournament/swiss/ListSortingPairing.java
+++ b/magic-server/src/main/java/magic/tournament/swiss/ListSortingPairing.java
@@ -1,11 +1,6 @@
 package magic.tournament.swiss;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableSet;
+import java.util.*;
 
 import org.chocosolver.solver.Solver;
 import org.chocosolver.solver.constraints.Constraint;
@@ -55,7 +50,7 @@ public class ListSortingPairing implements SwissPairingCalculator {
                                                               Collection<Player> playersInTier,
                                                               Map<Player, Integer> playerRankings) {
         List<Player> rankedPlayers = Lists.newArrayList(playersInTier);
-        Collections.sort(rankedPlayers, (a, b) -> playerRankings.get(a).compareTo(playerRankings.get(b)));
+        rankedPlayers.sort(Comparator.comparing(playerRankings::get));
         Map<Player, IntVar> result = Maps.newHashMap();
         for (int i = 0; i < rankedPlayers.size(); i++) {
             result.put(rankedPlayers.get(i), createPlayerVariable(solver, i, rangeStart, rangeEnd));
@@ -95,11 +90,11 @@ public class ListSortingPairing implements SwissPairingCalculator {
         Solver solver = new Solver();
         Map<Player, IntVar> playerVariables =
                 createPlayerVariables(solver, state.getPlayersAtEachPointLevel(), playerRankings);
-        disallowRepairing(solver, playerVariables, state.getSinglePurposeMap(d -> d.getAlreadyMatched()));
+        disallowRepairing(solver, playerVariables, state.getSinglePurposeMap(PlayerData::getAlreadyMatched));
         solver.post(ICF.alldifferent(playerVariables.values().toArray(new IntVar[0])));
         if (!solver.findSolution()) {
             throw new IllegalStateException("Could not find pairings!");
         }
-        return solutionToPairings(playerVariables, state.getSinglePurposeMap(d -> d.getPoints()));
+        return solutionToPairings(playerVariables, state.getSinglePurposeMap(PlayerData::getPoints));
     }
 }

--- a/magic-server/src/main/java/magic/tournament/swiss/PlayerData.java
+++ b/magic-server/src/main/java/magic/tournament/swiss/PlayerData.java
@@ -69,9 +69,6 @@ public final class PlayerData {
         } else if (!player.equals(other.player)) {
             return false;
         }
-        if (points != other.points) {
-            return false;
-        }
-        return true;
+        return points == other.points;
     }
 }

--- a/magic-server/src/main/java/magic/tournament/swiss/SwissTournament.java
+++ b/magic-server/src/main/java/magic/tournament/swiss/SwissTournament.java
@@ -1,13 +1,7 @@
 package magic.tournament.swiss;
 
 import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableSet;
-import java.util.Optional;
+import java.util.*;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -42,8 +36,7 @@ public class SwissTournament extends AbstractTournament {
                 db,
                 new TournamentData(
                         tournamentId,
-                        numberOfRounds.isPresent() ? numberOfRounds.get()
-                            : SwissTournament.getDefaultNumberOfRounds(input.getPlayers().size()),
+                        numberOfRounds.orElseGet(() -> SwissTournament.getDefaultNumberOfRounds(input.getPlayers().size())),
                         input,
                         ZonedDateTime.now(),
                         null,
@@ -75,16 +68,12 @@ public class SwissTournament extends AbstractTournament {
      * Returns a map that gives the position of each player relative to the others. The lowest value
      * in the map corresponds to the player that is doing the best.
      *
-     * @param pointsPerPlayer
-     * @param tieBreakers
-     * @return
      */
     public static LinkedHashMap<Player, Integer> rankPlayers(Collection<Player> allPlayers,
                                                               Map<Player, TieBreakers> tieBreakers) {
         LinkedHashMap<Player, Integer> rankings = Maps.newLinkedHashMap();
         List<Player> players = Lists.newArrayList(allPlayers);
-        Collections.sort(players, (a, b) -> tieBreakers.getOrDefault(a, TieBreakers.BYE).compareTo(
-        		tieBreakers.getOrDefault(b, TieBreakers.BYE)));
+        players.sort(Comparator.comparing(a -> tieBreakers.getOrDefault(a, TieBreakers.BYE)));
         for (int i = 0; i < players.size(); i++) {
             rankings.put(players.get(i), i);
         }

--- a/magic-server/src/main/java/magic/tournament/swiss/TournamentState.java
+++ b/magic-server/src/main/java/magic/tournament/swiss/TournamentState.java
@@ -26,7 +26,7 @@ public class TournamentState {
         if (roundData.size() % 2 != 0) {
         	Set<Player> alreadyHaveByes = data.stream()
         			.filter(d -> d.getAlreadyMatched().contains(Player.BYE))
-        			.map(d -> d.getPlayer())
+        			.map(PlayerData::getPlayer)
         			.collect(Collectors.toSet());
             roundData.put(Player.BYE, new PlayerData(Player.BYE, 0, alreadyHaveByes));
         }
@@ -36,7 +36,7 @@ public class TournamentState {
         Map<Player, Integer> points = Maps.newHashMap();
         Map<Player, Set<Player>> alreadyMatched = Maps.newHashMap();
         Set<Player> dropped = Sets.newHashSet();
-        rounds.stream().filter(r -> r.isComplete()).forEach(r -> {
+        rounds.stream().filter(Round::isComplete).forEach(r ->
             r.getMatches().forEach(m -> {
                 Player player1 = m.getPairing().getPlayer1();
                 Player player2 = m.getPairing().getPlayer2();
@@ -52,8 +52,8 @@ public class TournamentState {
                 if (m.isP2Drop()) {
                     dropped.add(player2);
                 }
-            });
-        });
+            })
+        );
         List<PlayerData> data = Lists.newArrayListWithCapacity(players.size());
         for (Player p : players) {
             if (dropped.contains(p)) {
@@ -68,20 +68,20 @@ public class TournamentState {
         return roundData;
     }
 
-    public Map<Integer, List<Player>> getPlayersAtEachPointLevel() {
+    /*package*/ Map<Integer, List<Player>> getPlayersAtEachPointLevel() {
         return roundData.values()
                 .stream()
                 .collect(
                         Collectors.toMap(
-                                d -> d.getPoints(),
-                                d -> Lists.<Player> newArrayList(d.getPlayer()),
+                                PlayerData::getPoints,
+                                d -> Lists.newArrayList(d.getPlayer()),
                                 (l1, l2) -> {
                                     l1.addAll(l2);
                                     return l1;
                                 }));
     }
 
-    public int getNumberOfPlayers() {
+    /*package*/ int getNumberOfPlayers() {
         return roundData.size();
     }
 
@@ -89,7 +89,7 @@ public class TournamentState {
         return roundData.keySet();
     }
 
-    public <T> Map<Player, T> getSinglePurposeMap(Function<PlayerData, T> fetcher) {
+    /*package*/ <T> Map<Player, T> getSinglePurposeMap(Function<PlayerData, T> fetcher) {
         return roundData.entrySet()
                 .stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> fetcher.apply(e.getValue())));

--- a/magic-server/src/test/java/magic/tournament/swiss/FullTournamentTests.java
+++ b/magic-server/src/test/java/magic/tournament/swiss/FullTournamentTests.java
@@ -45,13 +45,21 @@ public final class FullTournamentTests {
     private static final Player SAM      = new Player(3, "Sam");
     private static final Player RED_HULK = new Player(4, "Red hulk");
 
+    private static final Player DW = new Player(13, "DW");
+    private static final Player KV = new Player(17, "KV");
+    private static final Player BT = new Player(5, "DT");
+    private static final Player DT = new Player(32, "DT");
+    private static final Player BB = new Player(1, "BB");
+    private static final Player PW = new Player(63, "PW");
+
     private static final Pairing p1 = new Pairing(MIKE, KIMBERLY, 0);
     private static final Pairing p2 = new Pairing(SAM, RED_HULK, 0);
     private static final Pairing p3 = new Pairing(MIKE, RED_HULK, 6);
     private static final Pairing p4 = new Pairing(KIMBERLY, SAM, 0);
     private static final Pairing p5 = new Pairing(Player.BYE, SAM, 0);
 
-    private static final Result p1Win    = new Result(2, 0, 0);
+    private static final Result p1Win   = new Result(2, 1, 0);
+    private static final Result p1WinAll    = new Result(2, 0, 0);
     private static final Result p2Win    = new Result(1, 2, 0);
     private static final Result p2WinAll = new Result(0, 2, 0);
 
@@ -60,13 +68,14 @@ public final class FullTournamentTests {
         return Arrays.asList(new Object[][] {
                 {
                         "Basic smoke test",
+                        TOURNAMENT_ID,
                         ImmutableList.of(MIKE, KIMBERLY, SAM, RED_HULK),
                         ImmutableList.of(
                                 new Round(1, true, Sets.newTreeSet(ImmutableSet.of(
-                                        new Match(p1, p1Win, false, false),
+                                        new Match(p1, p1WinAll, false, false),
                                         new Match(p2, p2Win, false, false)))),
                                 new Round(2, true, Sets.newTreeSet(ImmutableSet.of(
-                                        new Match(p3, p1Win, false, false),
+                                        new Match(p3, p1WinAll, false, false),
                                         new Match(p4, p2Win, false, false))))),
                         ImmutableSortedSet.of(
                                 new TieBreakers(KIMBERLY, 0, .75, .2, .75, IGNORED),
@@ -76,13 +85,14 @@ public final class FullTournamentTests {
                 },
                 {
                         "Drop a player",
+                        TOURNAMENT_ID,
                         ImmutableList.of(MIKE, KIMBERLY, SAM, RED_HULK),
                         ImmutableList.of(
                                 new Round(1, true, Sets.newTreeSet(ImmutableSet.of(
-                                        new Match(p1, p1Win, false, true),
+                                        new Match(p1, p1WinAll, false, true),
                                         new Match(p2, p2Win, false, false)))),
                                 new Round(2, true, Sets.newTreeSet(ImmutableSet.of(
-                                        new Match(p3, p1Win, false, false),
+                                        new Match(p3, p1WinAll, false, false),
                                         new Match(p5, p2WinAll, false, false))))),
                         ImmutableSortedSet.of(
                                 new TieBreakers(KIMBERLY, 0, 1, 0, 1, IGNORED),
@@ -90,17 +100,46 @@ public final class FullTournamentTests {
                                 new TieBreakers(RED_HULK, 3, .75, .4, .8, IGNORED),
                                 new TieBreakers(MIKE, 6, .416667, 1, .366667, IGNORED)),
                 },
+                {
+                        "6 player bug",
+                        "b7992ed6-93cf-4723-a8ca-57ab7da64a3b",
+                        ImmutableList.of(DW, BT, BB, PW, KV, DT),
+                        ImmutableList.of(
+                                new Round(1, true, Sets.newTreeSet(ImmutableSet.of(
+                                        new Match(new Pairing(DW, KV, 0), p2WinAll, false, false),
+                                        new Match(new Pairing(BT, DT, 0), p1WinAll, false, false),
+                                        new Match(new Pairing(BB, PW, 0), p1Win, false, false)))),
+                                new Round(2, true, Sets.newTreeSet(ImmutableSet.of(
+                                        new Match(new Pairing(BB, BT, 6), p2Win, false, false),
+                                        new Match(new Pairing(KV, DT, 3), p2WinAll, false, false),
+                                        new Match(new Pairing(DW, PW, 0), p2Win, false, false)))),
+                                new Round(3, true, Sets.newTreeSet(ImmutableSet.of(
+                                        new Match(new Pairing(BT, KV, 9), p1WinAll, false, false),
+                                        new Match(new Pairing(DT, PW, 6), p1WinAll, false, false),
+                                        new Match(new Pairing(BB, DW, 3), p1WinAll, false, false))))
+                        ),
+                        ImmutableSortedSet.of(
+                                new TieBreakers(DW, 0, .444444, .142857, .444444, IGNORED),
+                                new TieBreakers(PW, 3, .555556, .375, .541667, IGNORED),
+                                new TieBreakers(KV, 3, .666667, .333333, .619048, IGNORED),
+                                new TieBreakers(BB,6, .555556, .625, .521825, IGNORED),
+                                new TieBreakers(DT, 6, .555556, .666667, .521825, IGNORED),
+                                new TieBreakers(BT, 9, .555556, 0.857143, .541667, IGNORED)),
+                },
         });
     }
 
+    private final String tournamentID;
     private final List<Player>               players;
     private final Collection<Round>         rounds;
     private final NavigableSet<TieBreakers> tieBreakers;
 
     public FullTournamentTests(String testName,
+                               String tournamentID,
                                List<Player> players,
                                Collection<Round> rounds,
                                NavigableSet<TieBreakers> tieBreakers) {
+        this.tournamentID = tournamentID;
         this.players = players;
         this.rounds = rounds;
         this.tieBreakers = tieBreakers;
@@ -110,7 +149,7 @@ public final class FullTournamentTests {
     public void test() {
         Tournament tournament = new SwissTournament(
                 NoopDB.NOOPDB,
-                TOURNAMENT_ID,
+                tournamentID,
                 new TournamentInput(Format.LIMITED_DRAFT, "ignore", this.players),
                 Optional.of(this.rounds.size()),
                 new GraphPairing());


### PR DESCRIPTION
Remember this one bill? 

The solution is within graphPairings. The basic problem was that the cost for crossing a point tier "boundary" (e.g. 9 points to 6 points) was only weighted by the number of players in that tier.

So crossing from 9 points to 0 points only cost 4. Crossing from 9 points to 6 cost 3 and crossing from 3 to 0 cost 1. 

Normally this wouldn't have been an issue, but it just so happens for this particular order of pairings and results the exact ranking within the 3 point tier was ideal. So rank 2 would play 3 and rank 4 would play 5. This was so cheap that it offset the cost of pairing 1 with 6.

Now it is very expensive to go across point tiers. It will only be done to avoid re-pairing players or similarly extreme cases.